### PR TITLE
Handle authenticated SOCKS5 proxies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,48 @@
+# Copilot instructions for `kimspect`
+
+## Build, test, and lint
+
+- Use the pinned Rust toolchain from `rust-toolchain.toml` (`1.90.0` with `rustfmt` and `clippy`).
+- Build locally with `cargo build` or `cargo build --release`.
+- CI lint commands are:
+  - `cargo clippy -- -D warnings`
+  - `cargo fmt --all -- --check --color always`
+- The pre-commit config also runs `cargo check` and `cargo clippy --fix --no-deps --allow-dirty --allow-staged`.
+- Run the full test suite with `cargo test`.
+- Run a single test by name with `cargo test test_process_pod`.
+- Run a single integration-test target and test with `cargo test --test cli_tests test_cli_parse_get_images_default`.
+- `tests/integration_tests.rs` uses a real Kubernetes client. CI starts a Kind cluster before `cargo test`, so cluster-dependent tests expect working kube access rather than mocks.
+
+## High-level architecture
+
+- `src/main.rs` is the binary entrypoint. It parses Clap args, initializes tracing, creates `K8sClient`, and dispatches the selected subcommand.
+- `src/lib.rs` re-exports the main CLI types, Kubernetes logic, and display helpers so the binary and integration tests use the same public API.
+- CLI definitions are split across `src/cli/args.rs`, `src/cli/commands.rs`, and `src/cli/formats.rs`:
+  - `Args` owns global flags like verbosity, log format, and request timeout.
+  - `Commands` / `GetImages` define the `get images` and `get registries` subcommands and their conflict rules.
+  - `OutputFormat` controls whether rendering stays in `normal` mode or expands to `wide`.
+- `src/k8s/mod.rs` is the core domain layer:
+  - `K8sClient` creates the `kube` client, checks cluster accessibility, validates namespaces, and fetches Kubernetes resources.
+  - `get_pod_images` lists pods, applies node/pod/registry filters, converts pods into `PodImage` records, then does a second pass over Node status to enrich image sizes from digests.
+  - `get_unique_registries` does **not** scan pods; it scans Deployment container specs and returns sorted unique registries.
+  - Image parsing lives in `extract_registry`, `split_image`, and `process_pod`.
+- `src/utils/mod.rs` is the presentation layer. It renders `PodImage` rows with `prettytable`; `wide` output is where registry, size, digest, and node columns are added.
+- `src/utils/logging.rs` owns tracing setup and maps `-v` counts to log levels.
+
+## Key conventions
+
+- Reuse the existing image-parsing helpers in `src/k8s/mod.rs` instead of reimplementing registry/tag/digest parsing. `tests/k8s_tests.rs` covers many edge cases, including registries with ports and digest-only image refs.
+- `PodImage` is the shared shape between Kubernetes collection and CLI rendering. If you add or rename image metadata, update both `process_pod` / `get_pod_images` and the table rendering in `src/utils/mod.rs`.
+- Preserve the current command/data-source split:
+  - `get images` is pod-based.
+  - `get registries` is deployment-based.
+  Changes that assume both commands read the same Kubernetes resource will be wrong.
+- Namespace handling is explicit. `K8sClient` checks namespace existence unless `--all-namespaces` is set, and empty results are often turned into `K8sError::ResourceNotFound` rather than silently returning an empty success.
+- Image size enrichment is best-effort. If listing Nodes fails, `get_pod_images` still returns image rows, just without size data.
+- CLI argument behavior is enforced in tests. When changing flags, keep the conflict/compatibility rules aligned with `tests/cli_tests.rs`:
+  - `--namespace` conflicts with `--all-namespaces`
+  - `--registry` conflicts with `--exclude-registry`
+  - `-o wide` enables the extra table columns
+- Logging follows the existing `tracing` + `anyhow::Context` + `#[instrument]` pattern. Match that style when adding new async Kubernetes operations.
+- The CLI currently parses `--kubeconfig`, but `K8sClient::new` still resolves kubeconfig from `KUBECONFIG` or `~/.kube/config`. If you work on kubeconfig handling, update both the CLI surface and the client wiring.
+- Formatting is intentionally opinionated: `rustfmt.toml` sets `max_width = 100` and related layout rules, and CI treats formatting drift as a failure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -548,7 +549,9 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -565,6 +568,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-terminal"
@@ -621,6 +630,9 @@ dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "http",
+ "hyper-timeout",
+ "hyper-util",
  "k8s-openapi",
  "kube",
  "mockall",
@@ -628,6 +640,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ prettytable-rs = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 thiserror = "2.0.12"
+hyper-timeout = "0.5.2"
+hyper-util = { version = "0.1.17", features = ["client-legacy", "client-proxy", "http1", "tokio"] }
+tower = "0.5.2"
+http = "1.3.1"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,6 +2,7 @@ use crate::cli::Commands;
 use crate::cli::formats::LogFormat;
 use clap::Parser;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Command line arguments for the Kimspect application
 #[derive(Parser, Debug)]
@@ -33,6 +34,10 @@ pub struct Args {
     )]
     pub log_format: LogFormat,
 
+    /// Timeout for Kubernetes API requests (e.g. 60s, 1m, 1m5s). Default: 30s
+    #[arg(long = "request-timeout", global = true, default_value = "30s", value_parser = parse_duration)]
+    pub request_timeout: Duration,
+
     /// The command to execute
     #[command(subcommand)]
     pub command: Commands,
@@ -49,4 +54,50 @@ impl Args {
             .clone()
             .or_else(|| std::env::var("KUBECONFIG").ok().map(PathBuf::from))
     }
+}
+
+/// Parse a human-readable duration string into a [`Duration`].
+///
+/// Supported formats: `60s`, `1m`, `1m5s` (minutes and/or seconds).
+fn parse_duration(s: &str) -> Result<Duration, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("duration must not be empty".into());
+    }
+
+    let mut remaining = s;
+    let mut total_secs: u64 = 0;
+    let mut parsed_any = false;
+
+    // Optional minutes component: <digits>m
+    if let Some(m_pos) = remaining.find('m') {
+        let minutes_str = &remaining[..m_pos];
+        let minutes: u64 = minutes_str
+            .parse()
+            .map_err(|_| format!("invalid minutes value in '{s}'"))?;
+        total_secs += minutes * 60;
+        remaining = &remaining[m_pos + 1..];
+        parsed_any = true;
+    }
+
+    // Optional seconds component: <digits>s
+    if let Some(s_pos) = remaining.find('s') {
+        let seconds_str = &remaining[..s_pos];
+        let seconds: u64 = seconds_str
+            .parse()
+            .map_err(|_| format!("invalid seconds value in '{s}'"))?;
+        total_secs += seconds;
+        remaining = &remaining[s_pos + 1..];
+        parsed_any = true;
+    }
+
+    if !remaining.is_empty() {
+        return Err(format!("unrecognised suffix '{remaining}' in '{s}' — expected format: 60s, 1m, 1m5s"));
+    }
+
+    if !parsed_any {
+        return Err(format!("'{s}' is not a valid duration — expected format: 60s, 1m, 1m5s"));
+    }
+
+    Ok(Duration::from_secs(total_secs))
 }

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -1,10 +1,21 @@
 use crate::utils::{KNOWN_REGISTRIES, strip_registry};
 use anyhow::{Context, Result};
+use hyper_timeout::TimeoutConnector;
+use hyper_util::{
+    client::legacy::connect::{HttpConnector, proxy::SocksV5},
+    rt::TokioExecutor,
+};
 use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::Node;
 use k8s_openapi::api::core::v1::Pod;
-use kube::{Api, Client, api::ListParams};
+use kube::{
+    Api, Client, Config,
+    api::ListParams,
+    client::ConfigExt,
+};
+use std::time::Duration;
 use thiserror::Error;
+use tower::{BoxError, ServiceBuilder};
 use tracing::{debug, error, info, instrument};
 
 /// Represents a container image running in a Kubernetes pod
@@ -60,15 +71,23 @@ impl K8sClient {
     ///
     /// * `Result<Self>` - A new K8sClient instance or an error if initialization fails
     #[instrument(skip_all)]
-    pub async fn new() -> Result<Self> {
+    pub async fn new(request_timeout: Duration) -> Result<Self> {
         debug!("Initializing Kubernetes client");
 
         let kubeconfig_path = Self::get_kubeconfig_path()?;
         debug!(path = %kubeconfig_path, "Using kubeconfig path");
 
-        let client = Client::try_default()
+        let mut config = Config::infer()
             .await
-            .context("Failed to create Kubernetes client")?;
+            .context("Failed to infer Kubernetes configuration")?;
+
+        debug!(
+            timeout_secs = request_timeout.as_secs(),
+            "Applying request timeout"
+        );
+        apply_request_timeout(&mut config, request_timeout);
+
+        let client = build_client(config).context("Failed to create Kubernetes client")?;
 
         let k8s_client = Self { client };
 
@@ -125,18 +144,22 @@ impl K8sClient {
             }
             Err(e) => match e {
                 kube::Error::Api(api_err) => {
-                    error!("Kubernetes API error occurred");
-                    Err(
-                        K8sError::ApiError(format!("{} ({})", api_err.message, api_err.reason))
-                            .into(),
-                    )
+                    error!(
+                        code = api_err.code,
+                        reason = %api_err.reason,
+                        message = %api_err.message,
+                        "Kubernetes API error occurred"
+                    );
+                    Err(K8sError::ApiError(format!(
+                        "{} ({}, code {})",
+                        api_err.message, api_err.reason, api_err.code
+                    ))
+                    .into())
                 }
                 _ => {
-                    error!("Failed to connect to Kubernetes cluster");
-                    Err(
-                        K8sError::ConnectionError("Failed to connect to Kubernetes cluster".into())
-                            .into(),
-                    )
+                    let message = format_connection_error(&e);
+                    error!(error = %e, "{message}");
+                    Err(K8sError::ConnectionError(message).into())
                 }
             },
         }
@@ -695,4 +718,369 @@ pub fn process_pod(pod: &Pod) -> Vec<PodImage> {
     }
 
     pod_images
+}
+
+fn format_connection_error(error: &dyn std::error::Error) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut current = error.source();
+
+    while let Some(source) = current {
+        let source_message = source.to_string();
+        let is_duplicate = parts.last() == Some(&source_message)
+            || parts
+                .last()
+                .is_some_and(|previous| previous.contains(&source_message));
+
+        if !is_duplicate {
+            parts.push(source_message);
+        }
+        current = source.source();
+    }
+
+    let joined = parts.join(" -> caused by: ");
+    let hint = connection_error_hint(&joined);
+
+    if let Some(hint) = hint {
+        format!(
+            "Failed to connect to Kubernetes cluster.\nCause: {joined}\nHint: {hint}"
+        )
+    } else {
+        format!("Failed to connect to Kubernetes cluster.\nCause: {joined}")
+    }
+}
+
+fn apply_request_timeout(config: &mut Config, request_timeout: Duration) {
+    config.connect_timeout = Some(request_timeout);
+    config.read_timeout = Some(request_timeout);
+    config.write_timeout = Some(request_timeout);
+}
+
+fn build_client(config: Config) -> Result<Client> {
+    if let Some(proxy_url) = config.proxy_url.as_ref() {
+        if proxy_url.scheme_str() == Some("socks5") {
+            return build_client_with_socks5_proxy(config);
+        }
+    }
+
+    Client::try_from(config).context("Failed to create default Kubernetes client")
+}
+
+fn build_client_with_socks5_proxy(config: Config) -> Result<Client> {
+    let default_namespace = config.default_namespace.clone();
+    let connector = build_socks5_connector(&config)?;
+    let connector = config
+        .rustls_https_connector_with_connector(connector)
+        .context("Failed to configure TLS connector for SOCKS5 proxy")?;
+    let mut connector = TimeoutConnector::new(connector);
+    connector.set_connect_timeout(config.connect_timeout);
+    connector.set_read_timeout(config.read_timeout);
+    connector.set_write_timeout(config.write_timeout);
+
+    let service = ServiceBuilder::new()
+        .layer(config.base_uri_layer())
+        .option_layer(config.auth_layer()?)
+        .layer(config.extra_headers_layer()?)
+        .map_err(BoxError::from)
+        .service(hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(connector));
+
+    Ok(Client::new(service, default_namespace))
+}
+
+fn build_socks5_connector(
+    config: &Config,
+) -> Result<SocksV5<HttpConnector>> {
+    let mut connector = HttpConnector::new();
+    connector.enforce_http(false);
+
+    let proxy_url = config
+        .proxy_url
+        .clone()
+        .context("SOCKS5 proxy requested but proxy URL is missing")?;
+
+    let (proxy_url, auth) = strip_proxy_userinfo(&proxy_url)?;
+    let connector = if let Some((user, pass)) = auth {
+        SocksV5::new(proxy_url, connector).with_auth(user, pass)
+    } else {
+        SocksV5::new(proxy_url, connector)
+    };
+
+    Ok(connector)
+}
+
+fn strip_proxy_userinfo(proxy_url: &http::Uri) -> Result<(http::Uri, Option<(String, String)>)> {
+    let Some(authority) = proxy_url.authority() else {
+        return Ok((proxy_url.clone(), None));
+    };
+
+    let authority_str = authority.as_str();
+    let Some((userinfo, host_port)) = authority_str.rsplit_once('@') else {
+        return Ok((proxy_url.clone(), None));
+    };
+
+    let (user, pass) = userinfo.split_once(':').unwrap_or((userinfo, ""));
+    let mut sanitized = format!(
+        "{}://{}",
+        proxy_url.scheme_str().unwrap_or("socks5"),
+        host_port
+    );
+
+    if let Some(path_and_query) = proxy_url.path_and_query() {
+        sanitized.push_str(path_and_query.as_str());
+    }
+
+    let sanitized_proxy_url = sanitized
+        .parse()
+        .context("Failed to parse SOCKS5 proxy URL without userinfo")?;
+
+    Ok((
+        sanitized_proxy_url,
+        Some((percent_decode(user)?, percent_decode(pass)?)),
+    ))
+}
+
+fn percent_decode(value: &str) -> Result<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = String::with_capacity(value.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len() {
+                anyhow::bail!("invalid percent-encoding in proxy credentials");
+            }
+
+            let hex = std::str::from_utf8(&bytes[index + 1..index + 3])
+                .context("Invalid UTF-8 in percent-encoded proxy credential")?;
+            let byte = u8::from_str_radix(hex, 16)
+                .with_context(|| format!("Invalid percent-encoding '%{hex}' in proxy credential"))?;
+            decoded.push(byte as char);
+            index += 3;
+        } else {
+            decoded.push(bytes[index] as char);
+            index += 1;
+        }
+    }
+
+    Ok(decoded)
+}
+
+fn connection_error_hint(message: &str) -> Option<&'static str> {
+    let lower = message.to_ascii_lowercase();
+
+    if lower.contains("deadline has elapsed") || lower.contains("timed out") {
+        return Some(
+            "the Kubernetes API connection timed out; verify network/proxy reachability and, if needed, increase --request-timeout",
+        );
+    }
+
+    if lower.contains("socks error") && lower.contains("does not support user/pass authentication")
+    {
+        return Some(
+            "the configured SOCKS5 proxy does not accept username/password authentication; verify the proxy auth method expected by this cluster context",
+        );
+    }
+
+    if lower.contains("socks error") && lower.contains("credentials not accepted") {
+        return Some(
+            "the configured SOCKS5 proxy rejected the supplied credentials; verify the proxy username and password in your kubeconfig",
+        );
+    }
+
+    if lower.contains("socks error") && lower.contains("authentication incorrectly") {
+        return Some(
+            "the SOCKS5 proxy and client disagreed on the negotiated authentication method; verify the proxy configuration for this context",
+        );
+    }
+
+    if lower.contains("socks error") && lower.contains("authentication") {
+        return Some(
+            "the configured SOCKS5 proxy failed during authentication; verify the proxy auth method and credentials for this context",
+        );
+    }
+
+    if lower.contains("socks error") {
+        return Some("the configured SOCKS5 proxy failed the connection; verify proxy settings");
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        apply_request_timeout, connection_error_hint, format_connection_error, percent_decode,
+        strip_proxy_userinfo,
+    };
+    use kube::Config;
+    use std::error::Error;
+    use std::fmt;
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct TestError {
+        message: &'static str,
+        source: Option<Box<dyn Error + Send + Sync>>,
+    }
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl Error for TestError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.source.as_deref().map(|source| source as _)
+        }
+    }
+
+    #[test]
+    fn test_format_connection_error_preserves_cause() {
+        let message = format_connection_error(&TestError {
+            message: "proxy requires kube/socks5",
+            source: None,
+        });
+        assert_eq!(
+            message,
+            "Failed to connect to Kubernetes cluster.\nCause: proxy requires kube/socks5"
+        );
+    }
+
+    #[test]
+    fn test_format_connection_error_includes_source_chain() {
+        let message = format_connection_error(&TestError {
+            message: "ServiceError: client error (Connect)",
+            source: Some(Box::new(TestError {
+                message: "tcp connect error",
+                source: Some(Box::new(TestError {
+                    message: "Connection refused (os error 111)",
+                    source: None,
+                })),
+            })),
+        });
+
+        assert_eq!(
+            message,
+            "Failed to connect to Kubernetes cluster.\nCause: ServiceError: client error (Connect) -> caused by: tcp connect error -> caused by: Connection refused (os error 111)"
+        );
+    }
+
+    #[test]
+    fn test_format_connection_error_skips_redundant_wrapped_source() {
+        let message = format_connection_error(&TestError {
+            message: "ServiceError: client error (Connect)",
+            source: Some(Box::new(TestError {
+                message: "client error (Connect)",
+                source: Some(Box::new(TestError {
+                    message: "SOCKS error: server does not support user/pass authentication",
+                    source: None,
+                })),
+            })),
+        });
+
+        assert_eq!(
+            message,
+            "Failed to connect to Kubernetes cluster.\nCause: ServiceError: client error (Connect) -> caused by: SOCKS error: server does not support user/pass authentication\nHint: the configured SOCKS5 proxy does not accept username/password authentication; verify the proxy auth method expected by this cluster context"
+        );
+    }
+
+    #[test]
+    fn test_apply_request_timeout_updates_connect_read_and_write() {
+        let mut config = Config::new("https://example.invalid".parse().unwrap());
+        let timeout = Duration::from_secs(90);
+
+        apply_request_timeout(&mut config, timeout);
+
+        assert_eq!(config.connect_timeout, Some(timeout));
+        assert_eq!(config.read_timeout, Some(timeout));
+        assert_eq!(config.write_timeout, Some(timeout));
+    }
+
+    #[test]
+    fn test_connection_error_hint_for_timeout() {
+        let hint = connection_error_hint(
+            "ServiceError: client error (Connect) -> caused by: deadline has elapsed",
+        );
+        assert_eq!(
+            hint,
+            Some(
+                "the Kubernetes API connection timed out; verify network/proxy reachability and, if needed, increase --request-timeout"
+            )
+        );
+    }
+
+    #[test]
+    fn test_connection_error_hint_for_socks_auth() {
+        let hint = connection_error_hint(
+            "ServiceError: client error (Connect) -> caused by: SOCKS error: server does not support user/pass authentication",
+        );
+        assert_eq!(
+            hint,
+            Some(
+                "the configured SOCKS5 proxy does not accept username/password authentication; verify the proxy auth method expected by this cluster context"
+            )
+        );
+    }
+
+    #[test]
+    fn test_connection_error_hint_for_socks_bad_credentials() {
+        let hint = connection_error_hint(
+            "ServiceError: client error (Connect) -> caused by: SOCKS error: credentials not accepted",
+        );
+        assert_eq!(
+            hint,
+            Some(
+                "the configured SOCKS5 proxy rejected the supplied credentials; verify the proxy username and password in your kubeconfig"
+            )
+        );
+    }
+
+    #[test]
+    fn test_connection_error_hint_for_socks_method_mismatch() {
+        let hint = connection_error_hint(
+            "ServiceError: client error (Connect) -> caused by: SOCKS error: server implements authentication incorrectly",
+        );
+        assert_eq!(
+            hint,
+            Some(
+                "the SOCKS5 proxy and client disagreed on the negotiated authentication method; verify the proxy configuration for this context"
+            )
+        );
+    }
+
+    #[test]
+    fn test_strip_proxy_userinfo_extracts_credentials() {
+        let proxy_url: http::Uri = "socks5://user:pass@proxy.example.com:1080/".parse().unwrap();
+
+        let (sanitized, auth) = strip_proxy_userinfo(&proxy_url).unwrap();
+
+        assert_eq!(sanitized.to_string(), "socks5://proxy.example.com:1080/");
+        assert_eq!(auth, Some(("user".into(), "pass".into())));
+    }
+
+    #[test]
+    fn test_strip_proxy_userinfo_decodes_percent_encoding() {
+        let proxy_url: http::Uri =
+            "socks5://foundation-platform:abc%40123@proxy.example.com:1080/".parse().unwrap();
+
+        let (_, auth) = strip_proxy_userinfo(&proxy_url).unwrap();
+
+        assert_eq!(auth, Some(("foundation-platform".into(), "abc@123".into())));
+    }
+
+    #[test]
+    fn test_strip_proxy_userinfo_without_auth_keeps_proxy() {
+        let proxy_url: http::Uri = "socks5://proxy.example.com:1080/".parse().unwrap();
+
+        let (sanitized, auth) = strip_proxy_userinfo(&proxy_url).unwrap();
+
+        assert_eq!(sanitized, proxy_url);
+        assert!(auth.is_none());
+    }
+
+    #[test]
+    fn test_percent_decode_rejects_invalid_encoding() {
+        let err = percent_decode("%zz").unwrap_err().to_string();
+        assert!(err.contains("Invalid percent-encoding"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> KimspectResult<()> {
     debug!("Application started with args: {:?}", args);
 
     // Create the client with improved error context
-    let client = K8sClient::new()
+    let client = K8sClient::new(args.request_timeout)
         .await
         .context("Failed to create Kubernetes client")?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,16 +1,21 @@
 use anyhow::Result;
 use kimspect::{K8sClient, K8sError};
+use std::time::Duration;
+
+fn integration_request_timeout() -> Duration {
+    Duration::from_secs(60)
+}
 
 #[tokio::test]
 async fn test_k8s_client_creation() -> Result<()> {
-    let client = K8sClient::new().await?;
+    let client = K8sClient::new(integration_request_timeout()).await?;
     assert!(client.is_accessible().await?);
     Ok(())
 }
 
 #[tokio::test]
 async fn test_get_pod_images() -> Result<()> {
-    let client = K8sClient::new().await?;
+    let client = K8sClient::new(integration_request_timeout()).await?;
     // Updated to include the new all_namespaces parameter
     let result = client
         .get_pod_images("default", None, None, None, &[], false)
@@ -41,7 +46,7 @@ async fn test_get_pod_images() -> Result<()> {
 
 #[tokio::test]
 async fn test_get_pod_images_with_node() -> Result<()> {
-    let client = K8sClient::new().await?;
+    let client = K8sClient::new(integration_request_timeout()).await?;
     // Test that we get a ResourceNotFound error when querying a non-existent node
     let result = client
         .get_pod_images("default", Some("non-existent-node"), None, None, &[], false)
@@ -52,7 +57,7 @@ async fn test_get_pod_images_with_node() -> Result<()> {
 
 #[tokio::test]
 async fn test_get_pod_images_all_namespaces() -> Result<()> {
-    let client = K8sClient::new().await?;
+    let client = K8sClient::new(integration_request_timeout()).await?;
     // Test the new all_namespaces functionality
     let _images = client
         .get_pod_images("default", None, None, None, &[], true)
@@ -64,7 +69,7 @@ async fn test_get_pod_images_all_namespaces() -> Result<()> {
 
 #[tokio::test]
 async fn test_get_pod_images_with_node_and_all_namespaces() -> Result<()> {
-    let client = K8sClient::new().await?;
+    let client = K8sClient::new(integration_request_timeout()).await?;
     // Test that we get a ResourceNotFound error when querying a non-existent node across all namespaces
     let result = client
         .get_pod_images("default", Some("non-existent-node"), None, None, &[], true)
@@ -75,7 +80,7 @@ async fn test_get_pod_images_with_node_and_all_namespaces() -> Result<()> {
 
 #[tokio::test]
 async fn test_get_pod_images_with_pod_and_all_namespaces() -> Result<()> {
-    let client = K8sClient::new().await?;
+    let client = K8sClient::new(integration_request_timeout()).await?;
     // Test that we get a ResourceNotFound error when querying a non-existent pod across all namespaces
     let result = client
         .get_pod_images("default", None, Some("non-existent-pod"), None, &[], true)
@@ -86,7 +91,7 @@ async fn test_get_pod_images_with_pod_and_all_namespaces() -> Result<()> {
 
 #[tokio::test]
 async fn test_get_unique_registries() -> Result<()> {
-    let client = K8sClient::new().await?;
+    let client = K8sClient::new(integration_request_timeout()).await?;
     let result = client.get_unique_registries("default", true).await;
 
     match result {


### PR DESCRIPTION
- preserve SOCKS5 proxy credentials from kubeconfig proxy-url entries
- apply --request-timeout to connect/read/write timeouts
- improve Kubernetes connection errors with cause and hint formatting
- document repository-specific Copilot guidance

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
